### PR TITLE
Fix WASM build error by disabling Linux-specific engines

### DIFF
--- a/scripts/build-openssl-wasm.sh
+++ b/scripts/build-openssl-wasm.sh
@@ -74,7 +74,8 @@ function build_openssl_libcrypto() {
 
   # Configure OpenSSL directly (no emconfigure) to avoid CROSS_COMPILE prefixing bugs.
   # Target a generic 32-bit linux and disable unsupported features in WASM.
-  perl ./Configure linux-generic32 no-asm no-shared no-threads no-dso no-ui no-tests -DOPENSSL_NO_SECURE_MEMORY
+  # Explicitly disable Linux-only engines (AFALG/devcrypto) and the engine subsystem entirely.
+  perl ./Configure linux-generic32 no-asm no-shared no-threads no-dso no-ui no-tests no-engine no-afalgeng no-devcryptoeng -DOPENSSL_NO_SECURE_MEMORY
 
   echo "Building libcrypto (this can take a while)..."
   make -j"${NPROC}" build_generated


### PR DESCRIPTION
This pull request addresses the build error encountered in the WASM build process due to the missing 'linux/version.h' file, which is part of the Linux kernel headers. To resolve this, I modified the build script to explicitly disable Linux-only engines such as AFALG and devcrypto. 

Changes made:
- Updated the OpenSSL configuration in `scripts/build-openssl-wasm.sh` to include options that disable the engine subsystem entirely, preventing the build process from trying to include unsupported components for WASM targets.

With these changes, the OpenSSL build should no longer attempt to reference Linux-specific headers, allowing for a successful WASM build.