### PR TITLE
Add NPM script to serve demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   "author": "Genie",
   "license": "MIT",
   "scripts": {
-    "build:wasm": "bash scripts/build-openssl-wasm.sh"
+    "build:wasm": "bash scripts/build-openssl-wasm.sh",
+    "serve:demo": "http-server -p 5173 -c-1 -o /examples/ ."
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
   }
 }


### PR DESCRIPTION
This pull request introduces a new NPM script `serve:demo` to the `package.json` file. This script utilizes `http-server` to serve the demo files located in the `/examples/` directory on port 5173. Additionally, `http-server` has been added to the `devDependencies`, ensuring that the necessary package is included for development purposes. This change simplifies the process of running the demo and provides a convenient command for users.