### PR TITLE
Add Vercel deployment script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,52 @@ Manual wiring example
 </script>
 ```
 
+Deploy to Vercel
+----------------
+This repo includes an npm script that prepares a deployable folder (vercel-build) and deploys it to Vercel. It:
+- Builds a fresh WASM (npm run build:wasm)
+- Copies the entire project into vercel-build (excluding dev/build artifacts)
+- Moves examples/index.html to vercel-build/index.html
+- Rewrites relative paths so index.html references dist and src from vercel-build root
+- Deploys vercel-build with the Vercel CLI
+
+Prerequisites (one-time):
+- Install Vercel CLI:
+  ```bash
+  npm i -g vercel
+  ```
+- Login:
+  ```bash
+  vercel login
+  ```
+- Link the deploy folder (must be done once before the first deployment):
+  - Ensure the folder exists:
+    ```bash
+    mkdir -p vercel-build
+    ```
+  - Link vercel-build to a Vercel project:
+    ```bash
+    vercel link --cwd vercel-build
+    ```
+    Follow the prompts to create/select a project and scope.
+
+Deploy
+- Run:
+  ```bash
+  npm run deploy:vercel
+  ```
+  The script will:
+  - Build fresh WASM
+  - Sync files into vercel-build
+  - Move examples/index.html to vercel-build/index.html
+  - Rewrite any ../dist/... and ../src/... references to dist/... and src/...
+  - Deploy vercel-build to production with Vercel
+
+Notes
+- If you relocate or rename examples/index.html, adjust the script at scripts/deploy-vercel.sh accordingly.
+- The script preserves vercel-build/.vercel, so you only need to run vercel link once.
+- You can view deployment logs and URLs in your Vercel dashboard.
+
 Notes on Security
 -----------------
 - WebOpenSSL uses cryptographically secure randomness:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "scripts": {
     "build:wasm": "bash scripts/build-openssl-wasm.sh",
-    "serve:demo": "http-server -p 5173 -c-1 -o /examples/ ."
+    "serve:demo": "http-server -p 5173 -c-1 -o /examples/ .",
+    "deploy:vercel": "bash scripts/deploy-vercel.sh"
   },
   "devDependencies": {
     "http-server": "^14.1.1"

--- a/scripts/deploy-vercel.sh
+++ b/scripts/deploy-vercel.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy the project to Vercel.
+# Steps:
+# 1) Build fresh WASM (npm run build:wasm)
+# 2) Create/refresh the vercel-build folder by copying the project (excluding dev/build artifacts)
+# 3) Move examples/index.html to vercel-build/index.html and rewrite relative paths
+# 4) Deploy vercel-build with Vercel CLI
+#
+# Prerequisites (one-time):
+# - npm i -g vercel
+# - vercel login
+# - vercel link --cwd vercel-build   (must exist; this script preserves .vercel)
+#
+# Notes:
+# - We preserve vercel-build/.vercel across runs so linking only needs to happen once.
+# - This script requires bash, rsync (optional), and sed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT}/vercel-build"
+
+# Check Vercel CLI
+if ! command -v vercel >/dev/null 2>&1; then
+  echo "ERROR: vercel CLI not found."
+  echo "Install with: npm i -g vercel"
+  exit 1
+fi
+
+echo "==> Step 1/4: Building fresh WASM"
+npm run build:wasm
+
+echo "==> Step 2/4: Preparing vercel-build folder"
+mkdir -p "${BUILD_DIR}"
+
+# Clean vercel-build except the .vercel metadata (to keep project link)
+if [ -d "${BUILD_DIR}" ]; then
+  shopt -s dotglob
+  for item in "${BUILD_DIR}"/*; do
+    name="$(basename "${item}")"
+    if [ "${name}" != ".vercel" ]; then
+      rm -rf "${item}"
+    fi
+  done
+  shopt -u dotglob
+fi
+
+# Copy project files to vercel-build while excluding unwanted directories
+echo "Copying project files into vercel-build..."
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a \
+    --exclude 'node_modules' \
+    --exclude '.git' \
+    --exclude '.gitignore' \
+    --exclude '.DS_Store' \
+    --exclude 'build' \
+    --exclude '.emsdk' \
+    --exclude 'vercel-build' \
+    --exclude '.vercel' \
+    "${ROOT}/" "${BUILD_DIR}/"
+else
+  echo "rsync not found; using cp fallback"
+  shopt -s dotglob
+  for entry in "${ROOT}"/*; do
+    base="$(basename "${entry}")"
+    case "${base}" in
+      node_modules|.git|.gitignore|.DS_Store|build|.emsdk|vercel-build|.vercel)
+        continue
+        ;;
+    esac
+    cp -a "${entry}" "${BUILD_DIR}/"
+  done
+  shopt -u dotglob
+fi
+
+# Move examples/index.html to the root of vercel-build and rewrite paths
+INDEX_SRC="${BUILD_DIR}/examples/index.html"
+INDEX_DST="${BUILD_DIR}/index.html"
+
+if [ -f "${INDEX_SRC}" ]; then
+  echo "==> Step 3/4: Moving examples/index.html to vercel-build/index.html"
+  mv -f "${INDEX_SRC}" "${INDEX_DST}"
+else
+  echo "WARNING: ${INDEX_SRC} not found. Ensure your demo page exists at examples/index.html"
+fi
+
+# Cross-platform sed inline helper
+sedi() {
+  # $1 = pattern, $2 = file
+  if sed --version >/dev/null 2>&1; then
+    sed -i -e "$1" "$2"
+  else
+    sed -i '' -e "$1" "$2"
+  fi
+}
+
+if [ -f "${INDEX_DST}" ]; then
+  echo "Rewriting relative paths inside index.html"
+  # Rewrite ../dist/... -> dist/...
+  sedi 's|src="../dist/|src="dist/|g' "${INDEX_DST}"
+  sedi 's|href="../dist/|href="dist/|g' "${INDEX_DST}"
+  sedi "s|url: '../dist/|url: 'dist/|g" "${INDEX_DST}"
+  sedi 's|url: "../dist/|url: "dist/|g' "${INDEX_DST}"
+
+  # Rewrite ../src/... -> src/...
+  sedi 's|src="../src/|src="src/|g' "${INDEX_DST}"
+  sedi 's|href="../src/|href="src/|g' "${INDEX_DST}"
+  sedi "s|url: '../src/|url: 'src/|g" "${INDEX_DST}"
+  sedi 's|url: "../src/|url: "src/|g' "${INDEX_DST}"
+fi
+
+# Ensure the Vercel project is linked
+if [ ! -f "${BUILD_DIR}/.vercel/project.json" ]; then
+  echo "ERROR: Vercel project is not linked for ${BUILD_DIR}."
+  echo "Run once to link this build directory:"
+  echo "  vercel link --cwd ${BUILD_DIR}"
+  exit 1
+fi
+
+echo "==> Step 4/4: Deploying vercel-build to Vercel (production)"
+vercel deploy --cwd "${BUILD_DIR}" --prod --yes
+
+echo "Deployment triggered. If this is your first deployment, Vercel will provide a URL."


### PR DESCRIPTION
This pull request introduces an npm script for deploying the application to Vercel. The script, `deploy:vercel`, performs the following steps:

1. Builds a fresh WASM using `npm run build:wasm`.
2. Copies all project files (excluding development artifacts) into a new folder called `vercel-build`.
3. Moves `index.html` from the `examples` directory to the root of `vercel-build`, adjusting file paths for proper referencing.
4. Deploys the `vercel-build` folder to Vercel using the Vercel CLI.

Additionally, the README.md has been updated with detailed instructions on how to set up Vercel CLI, link the project folder, and use the new deployment script.