### PR TITLE
Extend OpenSSL WASM for additional cryptographic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ API
 - setWasmModule(Module: EmscriptenModule) — configures OpenSSL WASM provider
 - getProviderName(): string
 - autoLoadOpenSSLWASM(options?: { url?: string; factoryGlobalName?: string }): Promise<boolean>
+- When OpenSSL WASM provider is loaded (openssl-wasm), additional functions are available:
+  - sha256(bytes: Uint8Array): Uint8Array (32 bytes)
+  - sha512(bytes: Uint8Array): Uint8Array (64 bytes)
+  - pbkdf2HmacSha256(password: Uint8Array, salt: Uint8Array, iterations: number, keyLen: number): Uint8Array
+  - pbkdf2HmacSha512(password: Uint8Array, salt: Uint8Array, iterations: number, keyLen: number): Uint8Array
+  - aes256GcmEncrypt(key: Uint8Array(32), iv: Uint8Array, aad: Uint8Array, plaintext: Uint8Array): { ciphertext: Uint8Array, tag: Uint8Array(16) }
+  - aes256GcmDecrypt(key: Uint8Array(32), iv: Uint8Array, aad: Uint8Array, ciphertext: Uint8Array, tag: Uint8Array(16)): Uint8Array
 
 Usage (Browser, min.js)
 -----------------------

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,10 @@
     button { padding: 0.6rem 1rem; border: 1px solid #ccc; border-radius: 6px; background: #fff; cursor: pointer; }
     button:hover { background: #f0f0f0; }
     .provider { color: #555; }
+    label { display: block; margin-top: 0.5rem; }
+    input[type="text"], input[type="number"], textarea { width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 6px; }
+    h2, h3 { margin-top: 2rem; }
+    .muted { color: #666; font-size: 0.95rem; }
   </style>
 </head>
 <body>
@@ -32,6 +36,77 @@
     <div id="khex32" class="key"></div>
   </div>
 
+  <h2>WASM-only functions (OpenSSL)</h2>
+  <p id="wasm-note" class="provider">These demos require the OpenSSL WASM provider. It will auto-load if available.</p>
+
+  <!-- Hashing -->
+  <div class="row">
+    <h3>Hashing (SHA-256 / SHA-512)</h3>
+    <label for="hash-input">Input text</label>
+    <input id="hash-input" type="text" value="hello">
+    <div style="margin-top: 0.5rem;">
+      <button id="btn-sha256" disabled>SHA-256</button>
+      <div class="key">
+        <div>SHA-256 (hex): <span id="sha256-hex"></span></div>
+        <div>SHA-256 (base64): <span id="sha256-b64"></span></div>
+      </div>
+    </div>
+    <div style="margin-top: 0.5rem;">
+      <button id="btn-sha512" disabled>SHA-512</button>
+      <div class="key">
+        <div>SHA-512 (hex): <span id="sha512-hex"></span></div>
+        <div>SHA-512 (base64): <span id="sha512-b64"></span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- PBKDF2 -->
+  <div class="row">
+    <h3>PBKDF2-HMAC (SHA-256 / SHA-512)</h3>
+    <label for="pbkdf2-pass">Password</label>
+    <input id="pbkdf2-pass" type="text" value="password">
+    <label for="pbkdf2-salt">Salt</label>
+    <input id="pbkdf2-salt" type="text" value="salt">
+    <button id="pbkdf2-random-salt" disabled>Generate random salt (16 bytes)</button>
+    <label for="pbkdf2-iter">Iterations</label>
+    <input id="pbkdf2-iter" type="number" value="100000" min="1">
+    <label for="pbkdf2-keylen">Key length (bytes)</label>
+    <input id="pbkdf2-keylen" type="number" value="32" min="1">
+
+    <div style="margin-top: 0.5rem;">
+      <button id="pbkdf2-256" disabled>Derive key (SHA-256)</button>
+      <div class="key">Hex: <span id="pbkdf2-256-hex"></span><br>Base64: <span id="pbkdf2-256-b64"></span></div>
+    </div>
+    <div style="margin-top: 0.5rem;">
+      <button id="pbkdf2-512" disabled>Derive key (SHA-512)</button>
+      <div class="key">Hex: <span id="pbkdf2-512-hex"></span><br>Base64: <span id="pbkdf2-512-b64"></span></div>
+    </div>
+  </div>
+
+  <!-- AES-256-GCM -->
+  <div class="row">
+    <h3>AES-256-GCM encrypt/decrypt</h3>
+    <p class="muted">Key and IV are generated randomly when the WASM provider loads.</p>
+    <div>Key (base64): <span id="aes-key-b64"></span></div>
+    <div>IV (base64): <span id="aes-iv-b64"></span></div>
+
+    <label for="aes-aad">AAD (optional)</label>
+    <input id="aes-aad" type="text" value="">
+
+    <label for="aes-pt">Plaintext</label>
+    <textarea id="aes-pt" rows="3">secret message</textarea>
+
+    <div style="margin-top: 0.5rem;">
+      <button id="aes-encrypt" disabled>Encrypt</button>
+      <div class="key">Ciphertext (base64): <span id="aes-ct-b64"></span><br>Tag (base64): <span id="aes-tag-b64"></span></div>
+    </div>
+
+    <div style="margin-top: 0.5rem;">
+      <button id="aes-decrypt" disabled>Decrypt</button>
+      <div class="key">Plaintext: <span id="aes-pt-out"></span></div>
+    </div>
+  </div>
+
   <script src="../dist/webopenssl.min.js"></script>
   <script>
     function updateProvider() {
@@ -39,12 +114,56 @@
     }
     updateProvider();
 
+    function bytesToHex(bytes) {
+      let s = "";
+      for (let i = 0; i < bytes.length; i++) {
+        let h = bytes[i].toString(16); if (h.length < 2) h = "0" + h; s += h;
+      }
+      return s;
+    }
+    function bytesToBase64(bytes) {
+      if (typeof Buffer !== "undefined" && typeof Buffer.from === "function") {
+        return Buffer.from(bytes).toString("base64");
+      }
+      let binary = "";
+      const chunkSize = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+      }
+      return btoa(binary);
+    }
+    function utf8Bytes(s) {
+      return new TextEncoder().encode(s);
+    }
+
     // Try to auto-load the OpenSSL WASM provider if available
+    let wasmLoaded = false;
     WebOpenSSL.autoLoadOpenSSLWASM({ url: '../dist/openssl-wasm/openssl_module.js' })
       .then((loaded) => {
-        if (loaded) updateProvider();
+        wasmLoaded = loaded;
+        if (loaded) {
+          document.getElementById('wasm-note').textContent = "OpenSSL WASM loaded.";
+          initAes();
+        } else {
+          document.getElementById('wasm-note').textContent = "OpenSSL WASM not found. WASM-only demos remain disabled.";
+        }
+        enableWasmDemos(loaded);
+        updateProvider();
       });
 
+    function enableWasmDemos(enabled) {
+      const ids = [
+        'btn-sha256','btn-sha512',
+        'pbkdf2-random-salt','pbkdf2-256','pbkdf2-512',
+        'aes-encrypt','aes-decrypt'
+      ];
+      ids.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.disabled = !enabled;
+      });
+    }
+
+    // Base random demos
     document.getElementById('gen32').addEventListener('click', () => {
       document.getElementById('k32').textContent = WebOpenSSL.randBase64(32);
     });
@@ -55,6 +174,86 @@
 
     document.getElementById('genhex32').addEventListener('click', () => {
       document.getElementById('khex32').textContent = WebOpenSSL.randHex(32);
+    });
+
+    // Hashing demos
+    document.getElementById('btn-sha256').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      const input = document.getElementById('hash-input').value;
+      const digest = WebOpenSSL.sha256(utf8Bytes(input));
+      document.getElementById('sha256-hex').textContent = bytesToHex(digest);
+      document.getElementById('sha256-b64').textContent = bytesToBase64(digest);
+    });
+
+    document.getElementById('btn-sha512').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      const input = document.getElementById('hash-input').value;
+      const digest = WebOpenSSL.sha512(utf8Bytes(input));
+      document.getElementById('sha512-hex').textContent = bytesToHex(digest);
+      document.getElementById('sha512-b64').textContent = bytesToBase64(digest);
+    });
+
+    // PBKDF2 demos
+    let pbkdf2SaltBytes = null;
+    document.getElementById('pbkdf2-random-salt').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      pbkdf2SaltBytes = WebOpenSSL.randBytes(16);
+      document.getElementById('pbkdf2-salt').value = '(random 16 bytes: ' + bytesToBase64(pbkdf2SaltBytes) + ')';
+    });
+
+    function getPbkdf2Params() {
+      const pass = document.getElementById('pbkdf2-pass').value;
+      const saltStr = document.getElementById('pbkdf2-salt').value;
+      const iterations = parseInt(document.getElementById('pbkdf2-iter').value, 10);
+      const keyLen = parseInt(document.getElementById('pbkdf2-keylen').value, 10);
+      const passBytes = utf8Bytes(pass);
+      const saltBytes = pbkdf2SaltBytes || utf8Bytes(saltStr);
+      return { passBytes, saltBytes, iterations, keyLen };
+    }
+
+    document.getElementById('pbkdf2-256').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      const { passBytes, saltBytes, iterations, keyLen } = getPbkdf2Params();
+      const key = WebOpenSSL.pbkdf2HmacSha256(passBytes, saltBytes, iterations, keyLen);
+      document.getElementById('pbkdf2-256-hex').textContent = bytesToHex(key);
+      document.getElementById('pbkdf2-256-b64').textContent = bytesToBase64(key);
+    });
+
+    document.getElementById('pbkdf2-512').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      const { passBytes, saltBytes, iterations, keyLen } = getPbkdf2Params();
+      const key = WebOpenSSL.pbkdf2HmacSha512(passBytes, saltBytes, iterations, keyLen);
+      document.getElementById('pbkdf2-512-hex').textContent = bytesToHex(key);
+      document.getElementById('pbkdf2-512-b64').textContent = bytesToBase64(key);
+    });
+
+    // AES-256-GCM demos
+    let aesKey = null, aesIv = null, lastCiphertext = null, lastTag = null;
+
+    function initAes() {
+      aesKey = WebOpenSSL.randBytes(32);
+      aesIv = WebOpenSSL.randBytes(12);
+      document.getElementById('aes-key-b64').textContent = bytesToBase64(aesKey);
+      document.getElementById('aes-iv-b64').textContent = bytesToBase64(aesIv);
+    }
+
+    document.getElementById('aes-encrypt').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      const aad = utf8Bytes(document.getElementById('aes-aad').value);
+      const plaintext = utf8Bytes(document.getElementById('aes-pt').value);
+      const { ciphertext, tag } = WebOpenSSL.aes256GcmEncrypt(aesKey, aesIv, aad, plaintext);
+      lastCiphertext = ciphertext;
+      lastTag = tag;
+      document.getElementById('aes-ct-b64').textContent = bytesToBase64(ciphertext);
+      document.getElementById('aes-tag-b64').textContent = bytesToBase64(tag);
+    });
+
+    document.getElementById('aes-decrypt').addEventListener('click', () => {
+      if (!wasmLoaded) return alert('OpenSSL WASM provider not loaded.');
+      if (!lastCiphertext || !lastTag) return alert('No ciphertext/tag available. Encrypt first.');
+      const aad = utf8Bytes(document.getElementById('aes-aad').value);
+      const plaintext = WebOpenSSL.aes256GcmDecrypt(aesKey, aesIv, aad, lastCiphertext, lastTag);
+      document.getElementById('aes-pt-out').textContent = new TextDecoder().decode(plaintext);
     });
   </script>
 </body>

--- a/scripts/build-openssl-wasm.sh
+++ b/scripts/build-openssl-wasm.sh
@@ -108,7 +108,7 @@ function build_wrapper_module() {
     -s ALLOW_MEMORY_GROWTH=1 \
     -s NO_FILESYSTEM=1 \
     -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
-    -s EXPORTED_FUNCTIONS="['_openssl_rand_bytes','_malloc','_free']" \
+    -s EXPORTED_FUNCTIONS="['_openssl_rand_bytes','_pbkdf2_hmac_sha256','_pbkdf2_hmac_sha512','_sha256_digest','_sha512_digest','_aes_256_gcm_encrypt','_aes_256_gcm_decrypt','_malloc','_free']" \
     -s EXPORTED_RUNTIME_METHODS="['cwrap']" \
     -o "${OUT_DIR}/openssl_module.js"
 

--- a/src/wasm/openssl_rand_wrapper.c
+++ b/src/wasm/openssl_rand_wrapper.c
@@ -1,7 +1,156 @@
 #include <openssl/rand.h>
+#include <openssl/evp.h>
+#include <openssl/sha.h>
 #include <stdint.h>
 
+/* Random bytes via OpenSSL RAND_bytes */
 int openssl_rand_bytes(int ptr, int len) {
     unsigned char *buf = (unsigned char*) (uintptr_t) ptr;
     return RAND_bytes(buf, len);
+}
+
+/* PBKDF2-HMAC-SHA256 */
+int pbkdf2_hmac_sha256(int pass_ptr, int pass_len,
+                       int salt_ptr, int salt_len,
+                       int iterations,
+                       int out_ptr, int out_len) {
+    const unsigned char *pass = (const unsigned char*)(uintptr_t) pass_ptr;
+    const unsigned char *salt = (const unsigned char*)(uintptr_t) salt_ptr;
+    unsigned char *out = (unsigned char*)(uintptr_t) out_ptr;
+    if (out_len <= 0 || iterations <= 0) return 0;
+    return PKCS5_PBKDF2_HMAC((const char*)pass, pass_len, salt, salt_len, iterations,
+                             EVP_sha256(), out_len, out);
+}
+
+/* PBKDF2-HMAC-SHA512 */
+int pbkdf2_hmac_sha512(int pass_ptr, int pass_len,
+                       int salt_ptr, int salt_len,
+                       int iterations,
+                       int out_ptr, int out_len) {
+    const unsigned char *pass = (const unsigned char*)(uintptr_t) pass_ptr;
+    const unsigned char *salt = (const unsigned char*)(uintptr_t) salt_ptr;
+    unsigned char *out = (unsigned char*)(uintptr_t) out_ptr;
+    if (out_len <= 0 || iterations <= 0) return 0;
+    return PKCS5_PBKDF2_HMAC((const char*)pass, pass_len, salt, salt_len, iterations,
+                             EVP_sha512(), out_len, out);
+}
+
+/* SHA-256 digest (32 bytes) */
+int sha256_digest(int data_ptr, int data_len, int out_ptr) {
+    const unsigned char *data = (const unsigned char*)(uintptr_t) data_ptr;
+    unsigned char *out = (unsigned char*)(uintptr_t) out_ptr;
+    unsigned char *ret = SHA256(data, (size_t)data_len, out);
+    return ret != NULL ? 1 : 0;
+}
+
+/* SHA-512 digest (64 bytes) */
+int sha512_digest(int data_ptr, int data_len, int out_ptr) {
+    const unsigned char *data = (const unsigned char*)(uintptr_t) data_ptr;
+    unsigned char *out = (unsigned char*)(uintptr_t) out_ptr;
+    unsigned char *ret = SHA512(data, (size_t)data_len, out);
+    return ret != NULL ? 1 : 0;
+}
+
+/* AES-256-GCM encrypt
+ * Inputs:
+ *  - key_ptr: 32-byte key
+ *  - iv_ptr / iv_len: IV (recommended 12 bytes)
+ *  - aad_ptr / aad_len: optional AAD (can be 0-length)
+ *  - plaintext_ptr / plaintext_len: plaintext to encrypt
+ * Outputs:
+ *  - ciphertext_ptr: buffer to receive ciphertext (size >= plaintext_len + 16)
+ *  - tag_ptr: buffer to receive 16-byte authentication tag
+ * Returns: ciphertext length on success, -1 on failure
+ */
+int aes_256_gcm_encrypt(int key_ptr,
+                        int iv_ptr, int iv_len,
+                        int aad_ptr, int aad_len,
+                        int plaintext_ptr, int plaintext_len,
+                        int ciphertext_ptr,
+                        int tag_ptr) {
+    const unsigned char *key = (const unsigned char*)(uintptr_t) key_ptr;
+    const unsigned char *iv = (const unsigned char*)(uintptr_t) iv_ptr;
+    const unsigned char *aad = (const unsigned char*)(uintptr_t) aad_ptr;
+    const unsigned char *plaintext = (const unsigned char*)(uintptr_t) plaintext_ptr;
+    unsigned char *ciphertext = (unsigned char*)(uintptr_t) ciphertext_ptr;
+    unsigned char *tag = (unsigned char*)(uintptr_t) tag_ptr;
+
+    int len = 0;
+    int ciphertext_len = 0;
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) return -1;
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, iv_len, NULL) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    if (EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+
+    if (aad && aad_len > 0) {
+        if (EVP_EncryptUpdate(ctx, NULL, &len, aad, aad_len) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    }
+
+    if (EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    ciphertext_len = len;
+
+    if (EVP_EncryptFinal_ex(ctx, ciphertext + ciphertext_len, &len) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    ciphertext_len += len;
+
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, tag) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+
+    EVP_CIPHER_CTX_free(ctx);
+    return ciphertext_len;
+}
+
+/* AES-256-GCM decrypt
+ * Inputs:
+ *  - key_ptr: 32-byte key
+ *  - iv_ptr / iv_len: IV (recommended 12 bytes)
+ *  - aad_ptr / aad_len: optional AAD (can be 0-length)
+ *  - ciphertext_ptr / ciphertext_len: ciphertext to decrypt
+ *  - tag_ptr: 16-byte authentication tag
+ * Output:
+ *  - plaintext_ptr: buffer to receive plaintext (size >= ciphertext_len)
+ * Returns: plaintext length on success, -1 on failure (including tag verification failure)
+ */
+int aes_256_gcm_decrypt(int key_ptr,
+                        int iv_ptr, int iv_len,
+                        int aad_ptr, int aad_len,
+                        int ciphertext_ptr, int ciphertext_len,
+                        int tag_ptr,
+                        int plaintext_ptr) {
+    const unsigned char *key = (const unsigned char*)(uintptr_t) key_ptr;
+    const unsigned char *iv = (const unsigned char*)(uintptr_t) iv_ptr;
+    const unsigned char *aad = (const unsigned char*)(uintptr_t) aad_ptr;
+    const unsigned char *ciphertext = (const unsigned char*)(uintptr_t) ciphertext_ptr;
+    const unsigned char *tag = (const unsigned char*)(uintptr_t) tag_ptr;
+    unsigned char *plaintext = (unsigned char*)(uintptr_t) plaintext_ptr;
+
+    int len = 0;
+    int plaintext_len = 0;
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) return -1;
+
+    if (EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, iv_len, NULL) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    if (EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+
+    if (aad && aad_len > 0) {
+        if (EVP_DecryptUpdate(ctx, NULL, &len, aad, aad_len) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    }
+
+    if (EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+    plaintext_len = len;
+
+    /* Set expected tag before finalizing */
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, (void*)tag) != 1) { EVP_CIPHER_CTX_free(ctx); return -1; }
+
+    if (EVP_DecryptFinal_ex(ctx, plaintext + plaintext_len, &len) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        return -1;
+    }
+    plaintext_len += len;
+
+    EVP_CIPHER_CTX_free(ctx);
+    return plaintext_len;
 }


### PR DESCRIPTION
This pull request enhances the OpenSSL WASM build by exporting additional cryptographic functions such as PBKDF2 with HMAC SHA-256 and SHA-512, as well as AES-256-GCM for encryption and decryption. 

**Changes include:**
- Updated `README.md` to document the new exported functions: `sha256`, `sha512`, `pbkdf2HmacSha256`, `pbkdf2HmacSha512`, `aes256GcmEncrypt`, and `aes256GcmDecrypt`.
- Modified the build script (`scripts/build-openssl-wasm.sh`) to include the new functions in the export list.
- Enhanced `src/index.js` to implement wrapper functions for the newly exported OpenSSL functions, ensuring appropriate error handling and memory management.
- Updated `src/wasm/openssl_rand_wrapper.c` to contain the logic for the newly added cryptographic functionalities.

These additions allow for greater flexibility and security in applications using the OpenSSL WASM provider.